### PR TITLE
Render MediaList as Media JSX Component

### DIFF
--- a/website/src/components/MediaPanel.tsx
+++ b/website/src/components/MediaPanel.tsx
@@ -86,17 +86,18 @@ const MediaList: MediaList[] = [
 export default function MedialPanel(): JSX.Element {
 	return (
 		<section>
-			{MediaList.map((props, idx) => {
-				;<Media key={idx} {...props} />
-			})}
+			{MediaList.map((props, idx) => (
+				<Media key={idx} {...props} />
+			))}
 		</section>
 	)
 }
+
 function Media({ ...props }: MediaList) {
 	return (
 		<div>
-			<div>{props.Episode}</div>
 			<div>{props.Description}</div>
+			<div>{props.Episode}</div>
 		</div>
 	)
 }


### PR DESCRIPTION
## Description

This pull request updates the `move-media-to-home` branch so  `MediaList` renders correctly through an iterating `Media` component. 

## Next Steps
Merge pull request and test on local development machine in order to move forward with completing homepage panel tasks.

## Screenshot of Expected Result
The following is how the homepage should render within the `dev` environment once pulled and built.

![Screenshot 2023-03-16 at 11 58 56](https://user-images.githubusercontent.com/6029572/225610050-d7ca2261-224b-4ed6-a633-b877a9c37d0f.png)
